### PR TITLE
🐛 修复上传文件为空时，indexdb记录没有删除

### DIFF
--- a/packages/baize-compress-image/lib/worker.ts
+++ b/packages/baize-compress-image/lib/worker.ts
@@ -35,12 +35,12 @@ self.onmessage = async (event) => {
   const params = JSON.parse(event.data);
   if (params.type === "compressImage") {
     const taskData = (await store.getItem(params.taskId)) as TaskType;
+    await store.removeItem(params.taskId);
     const file = taskData.file;
     const compressRes = await compressJpegImage({
       img: file.slice(0, file.size, file.type),
       quality: taskData.quality || DEFAULT_QUALITY,
     });
-    store.removeItem(params.taskId);
     store.setItem(params.taskId, compressRes);
     self.postMessage(
       JSON.stringify({


### PR DESCRIPTION
先压缩一张图片之后,文件上传了个空值，indexdb就会留下一条数据没删